### PR TITLE
Fix broken ERRNO compilation #Crystal 0.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Envoy UI
 [![](https://images.microbadger.com/badges/image/gonitro/envoy-ui.svg)](https://microbadger.com/images/gonitro/envoy-ui "Get your own image badge on microbadger.com")
 [![](https://images.microbadger.com/badges/version/gonitro/envoy-ui.svg)](https://microbadger.com/images/gonitro/envoy-ui "Get your own version badge on microbadger.com")
 
-A simple UI for Lyft's Envoy proxy that replicates some of the functionality of
+A simple UI for CNCF [Envoy proxy](https://www.envoyproxy.io/) that replicates some of the functionality of
 the HAproxy stats page. Intended to talk to a single instance of the proxy.
 
 Fetches statistics from `/clusters` and `/stats` on the Envoy node and renders
@@ -23,6 +23,17 @@ image](https://hub.docker.com/r/gonitro/envoy-ui/) or build the binaries
 yourself natively with [Crystal](https://crystal-lang.org). It has been
 tested on Linux and macOS.
 
+```
+$ crystal build --release envoy-ui.cr
+$ ./envoy-ui
+```
+
+To build an image locally and run a container
+```
+$ docker build -t envoy-ui .
+$ docker run envoy-ui
+```
+
 Configuration
 -------------
 
@@ -31,9 +42,9 @@ CLI flags:
 ```
 $ ./envoy-ui --help
 Usage: envoy-ui [arguments]
-    -h HOSTNAME, --host=HOSTNAME     Envoy proxy hostname
-    -p PORT, --port=PORT             Envoy proxy port
-    -l PORT, --listen-port=PORT      Port to listen on
+    -h HOSTNAME, --host=HOSTNAME     Envoy proxy hostname (defaults to localhost)
+    -p PORT, --port=PORT             Envoy proxy port (defaults to 9901)
+    -l PORT, --listen-port=PORT      Port to listen on (defaults to 8080)
     --help                           Show this help
 ```
 

--- a/envoy-ui.cr
+++ b/envoy-ui.cr
@@ -54,7 +54,7 @@ class EnvoyClient
     clusters = Hash(String, EnvoyCluster?).new
     response = begin
       @client.get "/clusters"
-    rescue ex : Errno
+    rescue ex : IO::Error
       return {err: ex.to_s, clusters: clusters}
     end
 
@@ -75,7 +75,7 @@ class EnvoyClient
     stats = Hash(String, String).new
     response = begin
       @client.get "/stats"
-    rescue ex : Errno
+    rescue ex : IO::Error
       return {err: ex.to_s, stats: stats}
     end
     if response.status_code != 200


### PR DESCRIPTION

## Motivation
- See #5 
- Crystal 0.34 got rid of [Errno](https://github.com/crystal-lang/crystal/pull/8885)

## What changed
- Fixed broken Errno compilation.
- Update README.

## How was this tested
- Tested with a locally running Envoy proxy
![image](https://user-images.githubusercontent.com/12872673/135745217-50c46f3b-e4d6-4d57-89c1-50212b6e83af.png)

